### PR TITLE
Add safety tag comment to LFS migration script

### DIFF
--- a/scripts/migrate_existing_files.sh
+++ b/scripts/migrate_existing_files.sh
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 require_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "Missing: $1"; exit 1; }; }
-require_cmd git
-require_cmd git-lfs
+require_cmd git; require_cmd git-lfs
 
+# Safety tag for rollback
 TAG="pre-lfs-migration-$(date +%Y%m%d-%H%M%S)"
 
 echo "Tagging current state as $TAG"


### PR DESCRIPTION
## Summary
- clarify LFS migration script by adding a rollback safety tag comment
- consolidate git requirement checks

## Testing
- `npm test` *(fails: package.json is invalid JSON)*
- `bash -n scripts/migrate_existing_files.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5ad7908fc833098cfb52ca1f15ee8