### PR TITLE
Fix Netlify config to allow Next.js routing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,3 @@
 [[plugins]]
   package = "@netlify/plugin-nextjs"
 
-[[redirects]]                       # SPA routing → always serve index.html
-  from = "/*"
-  to = "/index.html"
-  status = 200


### PR DESCRIPTION
## Summary
- remove Netlify catch-all redirect so Next.js plugin handles routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5dc17e5348330ae7d8d41070e7039