### PR TITLE
feat: add homepage links

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 export const metadata = {
   title: "WTP News",
 };
@@ -6,7 +8,29 @@ export default function Home() {
   return (
     <main>
       <h1>WTP News</h1>
-      <p>Welcome. Content coming soon.</p>
+      <p>Investigations, accountability, and civil-rights reporting.</p>
+      <nav>
+        <ul>
+          <li>
+            <Link href="/articles">Articles</Link>
+          </li>
+          <li>
+            <Link href="/documents">Documents</Link>
+          </li>
+          <li>
+            <Link href="/bad-actors-album">Bad Actors Album</Link>
+          </li>
+          <li>
+            <Link href="/constitutional-rights-tool">Constitutional Rights Tool</Link>
+          </li>
+          <li>
+            <Link href="/about">About</Link>
+          </li>
+          <li>
+            <Link href="/contact">Contact</Link>
+          </li>
+        </ul>
+      </nav>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add navigation to home page linking to key sections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5df169aac833096f709f1ec5e45ed